### PR TITLE
Fix build for kernel>=6.8.0

### DIFF
--- a/aziokbd.c
+++ b/aziokbd.c
@@ -423,12 +423,24 @@ static int usb_kbd_probe(struct usb_interface *iface,
 	kbd->dev = input_dev;
 
 	if (dev->manufacturer)
-		strlcpy(kbd->name, dev->manufacturer, sizeof(kbd->name));
+		#if LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0)
+			strlcpy(kbd->name, dev->manufacturer, sizeof(kbd->name));
+		#else
+			strscpy(kbd->name, dev->manufacturer, sizeof(kbd->name));
+		#endif
 
 	if (dev->product) {
 		if (dev->manufacturer)
-			strlcat(kbd->name, " ", sizeof(kbd->name));
-		strlcat(kbd->name, dev->product, sizeof(kbd->name));
+			#if LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0)
+				strlcat(kbd->name, " ", sizeof(kbd->name));
+			#else
+				strncat(kbd->name, " ", sizeof(kbd->name));
+			#endif
+		#if LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0)
+			strlcat(kbd->name, dev->product, sizeof(kbd->name));
+		#else
+			strncat(kbd->name, dev->product, sizeof(kbd->name));
+		#endif
 	}
 
 	if (!strlen(kbd->name))
@@ -440,7 +452,11 @@ static int usb_kbd_probe(struct usb_interface *iface,
 	printk("<1>aziokbd: detected %s\n", kbd->name);
 
 	usb_make_path(dev, kbd->phys, sizeof(kbd->phys));
-	strlcat(kbd->phys, "/input0", sizeof(kbd->phys));
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0)
+		strlcat(kbd->phys, "/input0", sizeof(kbd->phys));
+	#else
+		strncat(kbd->phys, "/input0", sizeof(kbd->phys));
+	#endif
 
 	input_dev->name = kbd->name;
 	input_dev->phys = kbd->phys;

--- a/install.sh
+++ b/install.sh
@@ -25,23 +25,22 @@ quirk='0x0c45:0x7603:0x4'
 grubquirk="usbhid.quirks=$quirk"
 
 # Making sure the quirk does not get added multiple times
-GRUBCONF=/etc/default/grub.d/aziokbd.cfg
-if ! (cat $GRUBCONF | grep "$grubquirk"); then
-    echo '## Writing to $GRUBCONF'
-    echo "GRUB_CMDLINE_LINUX_DEFAULT=\"\$GRUB_CMDLINE_LINUX_DEFAULT $grubquirk\"" >> $GRUBCONF
-    distro=$(lsb_release -si)
-    case $distro in 
-        'Ubuntu'|'Debian'):
-            update-grub
-            ;;
-        *):
-            if [ -f "/etc/arch-release" ]; then
-                update-grub
-            elif [ -f "/etc/fedora-release" ]; then
-                grub2-mkconfig -o /boot/grub2/grub.cfg
-            fi
-	    ;;
-    esac
+if ! (cat /etc/default/grub.d/aziokbd.conf | grep "$grubquirk"); then
+    echo '## Writing to /etc/default/grub.d/aziokbd.conf ##'
+    echo $grubquirk >> /etc/default/grub.d/aziokbd.conf
+    distro = $(lsb_release -si)
+    if ($distro | grep 'Ubuntu'); then
+        update-grub
+    fi
+    if ($distro | grep 'Debian'); then
+        update-grub
+    fi
+    if [ -f "/etc/arch-release" ]; then
+        update-grub
+    fi
+    if [ -f "/etc/fedora-release" ]; then
+        grub2-mkconfig -o /boot/grub2/grub.cfg
+    fi
 else
     echo 'NOTICE - grub config file has already been updated'
 fi

--- a/install.sh
+++ b/install.sh
@@ -25,22 +25,23 @@ quirk='0x0c45:0x7603:0x4'
 grubquirk="usbhid.quirks=$quirk"
 
 # Making sure the quirk does not get added multiple times
-if ! (cat /etc/default/grub.d/aziokbd.conf | grep "$grubquirk"); then
-    echo '## Writing to /etc/default/grub.d/aziokbd.conf ##'
-    echo $grubquirk >> /etc/default/grub.d/aziokbd.conf
-    distro = $(lsb_release -si)
-    if ($distro | grep 'Ubuntu'); then
-        update-grub
-    fi
-    if ($distro | grep 'Debian'); then
-        update-grub
-    fi
-    if [ -f "/etc/arch-release" ]; then
-        update-grub
-    fi
-    if [ -f "/etc/fedora-release" ]; then
-        grub2-mkconfig -o /boot/grub2/grub.cfg
-    fi
+GRUBCONF=/etc/default/grub.d/aziokbd.cfg
+if ! (cat $GRUBCONF | grep "$grubquirk"); then
+    echo '## Writing to $GRUBCONF'
+    echo "GRUB_CMDLINE_LINUX_DEFAULT=\"\$GRUB_CMDLINE_LINUX_DEFAULT $grubquirk\"" >> /etc/default/grub.d/aziokbd.cfg
+    distro=$(lsb_release -si)
+    case $distro in 
+        'Ubuntu'|'Debian'):
+            update-grub
+            ;;
+        *):
+            if [ -f "/etc/arch-release" ]; then
+                update-grub
+            elif [ -f "/etc/fedora-release" ]; then
+                grub2-mkconfig -o /boot/grub2/grub.cfg
+            fi
+	    ;;
+    esac
 else
     echo 'NOTICE - grub config file has already been updated'
 fi

--- a/install.sh
+++ b/install.sh
@@ -25,22 +25,23 @@ quirk='0x0c45:0x7603:0x4'
 grubquirk="usbhid.quirks=$quirk"
 
 # Making sure the quirk does not get added multiple times
-if ! (cat /etc/default/grub.d/aziokbd.conf | grep "$grubquirk"); then
-    echo '## Writing to /etc/default/grub.d/aziokbd.conf ##'
-    echo $grubquirk >> /etc/default/grub.d/aziokbd.conf
-    distro = $(lsb_release -si)
-    if ($distro | grep 'Ubuntu'); then
-        update-grub
-    fi
-    if ($distro | grep 'Debian'); then
-        update-grub
-    fi
-    if [ -f "/etc/arch-release" ]; then
-        update-grub
-    fi
-    if [ -f "/etc/fedora-release" ]; then
-        grub2-mkconfig -o /boot/grub2/grub.cfg
-    fi
+GRUBCONF=/etc/default/grub.d/aziokbd.cfg
+if ! (cat $GRUBCONF | grep "$grubquirk"); then
+    echo '## Writing to $GRUBCONF'
+    echo "GRUB_CMDLINE_LINUX_DEFAULT=\"\$GRUB_CMDLINE_LINUX_DEFAULT $grubquirk\"" >> $GRUBCONF
+    distro=$(lsb_release -si)
+    case $distro in 
+        'Ubuntu'|'Debian'):
+            update-grub
+            ;;
+        *):
+            if [ -f "/etc/arch-release" ]; then
+                update-grub
+            elif [ -f "/etc/fedora-release" ]; then
+                grub2-mkconfig -o /boot/grub2/grub.cfg
+            fi
+	    ;;
+    esac
 else
     echo 'NOTICE - grub config file has already been updated'
 fi


### PR DESCRIPTION
With kernel >=6.8 the build fails, this commit adds a check for kernel version>=6.8 in order of replace strlcpy (seems deprecated in >=6.8) with strscopy and strlcat wih strncat (altough it builds with strlcat).